### PR TITLE
Message lines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ This project strives to use [semantic commit messages](https://seesparkbox.com/f
 - `test` - indicates updates to test code.
 - `slug` - indicates a useless commit, such as causing a ci rebuild. These should be rebased together prior
   to merging if at all possible.
-- `design` - indicates stylesheet changes or other visual updates
+- `design` - indicates style changes or other visual updates
 
 In addition, an optional second tier of description can be added if helpful with parenthesis. This
 is usually used to provide context on a code update, a chore, or a slug.

--- a/frontend/draw_messages.go
+++ b/frontend/draw_messages.go
@@ -287,61 +287,35 @@ func (term *TerminalDisplay) DrawMessages(
 			return 0, false
 		}
 
-		// The number of characters from the left that messages should be offset by.
-		messageOffset := 0
-
-		// Draw a relative line number at the start of the line, if requested.
-		if _, ok := config["Message.RelativeLine"]; ok {
-			messageOffset += relativeLineWidth + 1 // Each line number needs this many columns, +1 padding
-		}
-
-		messageOffset += len(timestamp) + 1
-
-		if msg.Sender != nil && userOnline(msg.Sender) {
-			messageOffset += len(config["Message.Sender.OnlinePrefix"])
-		} else if msg.Sender != nil {
-			messageOffset += len(config["Message.Sender.OfflinePrefix"])
-		}
-
-		messageOffset += len(sender)
-
-
-
 		// Calculate how many rows the message requires to render.
-		messageColumnWidth := width - prefixWidth - messageOffset
+		messageColumnWidth := width - prefixWidth
 		parsedMessageLines := parsedMessage.Lines(messageColumnWidth)
 		messageRows := len(parsedMessageLines)
+		accessoryRow := row // The row to start rendering "message accessories" on
+		if len(msg.Text) == 0 {
+			accessoryRow -= 1
+		}
+		if len(msg.Reactions) > 0 { // Reactions need one row
+			messageRows += 1
+			accessoryRow -= 1
+		}
+		if msg.File != nil { // Files need one row
+			messageRows += 1
+			accessoryRow -= 1
+		}
+		if msg.Attachments != nil { // Attachments need a lot of rows. :(
+			// Collect the total attachment height
+			var attachmentSize int
+			for _, attach := range *msg.Attachments {
+				attachmentSize += getAttachmentHeight(attach)
+			}
 
-		messageOffset = 0
-
-		// Draw the sender, the sender's online status, and the timestamp on the first row of a message
-		term.WriteTextStyle(messageOffset, row-messageRows+1, selectedStyle, timestamp)
-		messageOffset += len(timestamp) + 1
-
-		if msg.Sender != nil && userOnline(msg.Sender) {
-			// Render online status for sender
-			term.WriteTextStyle(
-				messageOffset,
-				row-messageRows+1,
-				color.DeSerializeStyleTcell(config["Message.Sender.OnlinePrefixColor"]),
-				config["Message.Sender.OnlinePrefix"],
-			)
-			messageOffset += len(config["Message.Sender.OnlinePrefix"])
-		} else if msg.Sender != nil {
-			// Render offline status for sender
-			term.WriteTextStyle(
-				messageOffset,
-				row-messageRows+1,
-				color.DeSerializeStyleTcell(config["Message.Sender.OfflinePrefixColor"]),
-				config["Message.Sender.OfflinePrefix"],
-			)
-			messageOffset += len(config["Message.Sender.OfflinePrefix"])
+			messageRows += attachmentSize
+			accessoryRow -= attachmentSize
 		}
 
-		term.WriteTextStyle(messageOffset, row-messageRows+1, senderStyle, sender)
-		messageOffset += len(sender)
-
-
+		// The number of characters from the left that messages should be offset by.
+		messageOffset := 0
 
 		// Draw a relative line number at the start of the line, if requested.
 		var lineNumberStyle tcell.Style
@@ -374,31 +348,36 @@ func (term *TerminalDisplay) DrawMessages(
 					content,
 				)
 			}
+
+			messageOffset += relativeLineWidth + 1 // Each line number needs this many columns, +1 padding
 		}
 
+		// Draw the sender, the sender's online status, and the timestamp on the first row of a message
+		term.WriteTextStyle(messageOffset, row-messageRows+1, selectedStyle, timestamp)
+		messageOffset += len(timestamp) + 1
 
-		accessoryRow := row // The row to start rendering "message accessories" on
-		if len(msg.Text) == 0 {
-			accessoryRow -= 1
+		if msg.Sender != nil && userOnline(msg.Sender) {
+			// Render online status for sender
+			term.WriteTextStyle(
+				messageOffset,
+				row-messageRows+1,
+				color.DeSerializeStyleTcell(config["Message.Sender.OnlinePrefixColor"]),
+				config["Message.Sender.OnlinePrefix"],
+			)
+			messageOffset += len(config["Message.Sender.OnlinePrefix"])
+		} else if msg.Sender != nil {
+			// Render offline status for sender
+			term.WriteTextStyle(
+				messageOffset,
+				row-messageRows+1,
+				color.DeSerializeStyleTcell(config["Message.Sender.OfflinePrefixColor"]),
+				config["Message.Sender.OfflinePrefix"],
+			)
+			messageOffset += len(config["Message.Sender.OfflinePrefix"])
 		}
-		if len(msg.Reactions) > 0 { // Reactions need one row
-			messageRows += 1
-			accessoryRow -= 1
-		}
-		if msg.File != nil { // Files need one row
-			messageRows += 1
-			accessoryRow -= 1
-		}
-		if msg.Attachments != nil { // Attachments need a lot of rows. :(
-			// Collect the total attachment height
-			var attachmentSize int
-			for _, attach := range *msg.Attachments {
-				attachmentSize += getAttachmentHeight(attach)
-			}
 
-			messageRows += attachmentSize
-			accessoryRow -= attachmentSize
-		}
+		term.WriteTextStyle(messageOffset, row-messageRows+1, senderStyle, sender)
+		messageOffset += len(sender)
 
 		// Render optional reactions, file, or attachment after message
 		if msg.File != nil {

--- a/gateway/printable_message.go
+++ b/gateway/printable_message.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"log"
 	"strings"
 )
 
@@ -69,16 +68,20 @@ func (p *PrintableMessage) Lines(width int) [][]PrintableMessagePart {
 	var lineBeingAssembled []PrintableMessagePart
 	lineWidth := 0
 	for _, part := range p.parts {
+
+    // Handle newlines. If we come across a newline, add the "working" line to the lines array and
+    // create a new working line.
+    if part.Type == PRINTABLE_MESSAGE_NEWLINE {
+      lines = append(lines, lineBeingAssembled)
+      lineBeingAssembled = make([]PrintableMessagePart, 0)
+    }
+
+    // Is the current part have to wrap to fit on the current width
 		if lineWidth + len(part.Content) > width {
 			widthRemainingInLine := width - lineWidth
 
-			if part.Type == PRINTABLE_MESSAGE_NEWLINE {
-				lines = append(lines, lineBeingAssembled)
-				lineBeingAssembled = make([]PrintableMessagePart, 0)
-			}
-			
 			content := part.Content
-			for len(content) > width {
+			for len(content) > widthRemainingInLine {
 				// The goal is to split the part in two - the first bit goes on the current line, the second bit is saved for the next iteration.
 				
 				// Attempt to split the part at a space, if possible. If not, just split in the middle of a word.
@@ -124,12 +127,14 @@ func (p *PrintableMessage) Lines(width int) [][]PrintableMessagePart {
 	return lines
 }
 
-func (p *PrintableMessage) Print(width int) {
+func (p *PrintableMessage) Sprint(width int) string {
+	total := ""
 	for _, line := range p.Lines(width) {
 		lineContent := ""
 		for _, part := range line {
 			lineContent += part.Content
 		}
-		fmt.Println(lineContent)
+		total += lineContent + "\n"
 	}
+	return total
 }

--- a/gateway/printable_message.go
+++ b/gateway/printable_message.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"log"
 	"strings"
 )
 
@@ -63,94 +64,72 @@ func (p *PrintableMessage) Plain() string {
 }
 
 func (p *PrintableMessage) Lines(width int) [][]PrintableMessagePart {
-	// If the result has already been calculated, use it.
-	if p.linesCacheWidth == width && p.linesCache != nil {
-		return p.linesCache
-	}
-
 	var lines [][]PrintableMessagePart
-	var messageParts []PrintableMessagePart
-	var extraWords []string
-
+	
+	var lineBeingAssembled []PrintableMessagePart
+	lineWidth := 0
 	for _, part := range p.parts {
-		messageParts = append(messageParts, part)
+		if lineWidth + len(part.Content) > width {
+			widthRemainingInLine := width - lineWidth
 
-		// If a newline was found, then force a line break, and clear the parts on the current line.
-		if part.Type == PRINTABLE_MESSAGE_NEWLINE {
-			lines = append(lines, messageParts)
-			messageParts = make([]PrintableMessagePart, 0)
-		}
-
-
-		pm := PrintableMessage{parts: messageParts}
-		if pm.Length() > width {
-			pm = PrintableMessage{parts: messageParts[:len(messageParts)-1]}
-			maximumLengthOfLastMessagePart := width - pm.Length()
-
-			// log.Printf("WANTED TO DRAW %+v BUT INSTEAD ONLY DID %d", messageParts, maximumLengthOfLastMessagePart)
-
-			// Now, cut down all words that don't fit on this line.
-			// foo bar baz hello world test quux (extraWords = [])
-			// foo bar baz hello world test      (extraWords = [quux])
-			// foo bar baz hello world           (extraWords = [test, quux])
-			// foo bar baz hello                 (extraWords = [world, test, quux])
-			//                    ^
-			//                 "window width"
-			// (done, since the line length < window width)
-
-			wordsInLastMessagePart := strings.Split(part.Content, " ")
-			for len(strings.Join(wordsInLastMessagePart, " ")) > maximumLengthOfLastMessagePart {
-				if len(wordsInLastMessagePart) < 1 { // Make sure that there are words to split on. Fixes #9.
-					break
+			if part.Type == PRINTABLE_MESSAGE_NEWLINE {
+				lines = append(lines, lineBeingAssembled)
+				lineBeingAssembled = make([]PrintableMessagePart, 0)
+			}
+			
+			content := part.Content
+			for len(content) > width {
+				// The goal is to split the part in two - the first bit goes on the current line, the second bit is saved for the next iteration.
+				
+				// Attempt to split the part at a space, if possible. If not, just split in the middle of a word.
+				// (Look for the last space in the "first bit" of the string, and split at that marker)
+				amountOfLineUsed := strings.LastIndex(content[:widthRemainingInLine], " ")+1
+				if amountOfLineUsed <= 0 {
+					amountOfLineUsed = widthRemainingInLine
 				}
-
-				// Remove one word from the last message part
-				extraWords = append([]string{wordsInLastMessagePart[len(wordsInLastMessagePart)-1]}, extraWords...)
-				wordsInLastMessagePart = wordsInLastMessagePart[:len(wordsInLastMessagePart)-1]
+				
+				// Append the first bit to the current line
+				firstBit := PrintableMessagePart{Type: part.Type, Content: content[:amountOfLineUsed], Metadata: part.Metadata}
+				lineBeingAssembled = append(lineBeingAssembled, firstBit)
+			
+				// Append the current line to the lines collection.
+				lines = append(lines, lineBeingAssembled)
+				lineBeingAssembled = make([]PrintableMessagePart, 0)
+				
+				// Remove the chunk already used from the message content.
+				content = content[amountOfLineUsed:]
+				
+				// Parts after the first part should be full width - ie:
+				//          |         | <= Partial width
+				// #general The quick b
+				// |                  | <= Full width
+				// rown fox jumps over 
+				// the lazy dog
+				widthRemainingInLine = width
 			}
-
-			// If the last message part in a line has content to append, then add it. However, if
-			// it's empty (probably because all the words were moved to the next line) then delete
-			// it (since its content would just be "" anyway)
-			if len(wordsInLastMessagePart) > 0 {
-				messageParts[len(messageParts)-1].Content = strings.Join(wordsInLastMessagePart, " ")
-			} else {
-				messageParts = messageParts[:len(messageParts)-1]
-			}
-
-			// log.Printf("ACTUALLY DRAWING %+v", messageParts)
-
-			// Now that our line is below the max width, it can be drawn, so add it to the array.
-			if len(messageParts) > 0 {
-				lines = append(lines, messageParts)
-			}
-			// log.Printf("LINES %+v", lines)
-
-			// Then, clear out the message parts that have been used so far.
-			messageParts = make([]PrintableMessagePart, 0)
-
-			// And start off the next line with any words that were removed from the current line to
-			// make it fit.
-			if len(extraWords) > 0 {
-				messageParts = append(messageParts, PrintableMessagePart{
-					Type:    part.Type,
-					Content: strings.Join(extraWords, " "),
-				})
-				extraWords = make([]string, 0)
-			}
-			// log.Printf("LINE BIT CUT OFF %+v", messageParts)
+			
+			// Finally, append the final bit that was left unhandled.
+			finalBit := PrintableMessagePart{Type: part.Type, Content: content, Metadata: part.Metadata}
+			lineBeingAssembled = append(lineBeingAssembled, finalBit)
+		} else {
+			// Add the part to the end of the line if it fits on the line.
+			lineWidth += len(part.Content)
+			lineBeingAssembled = append(lineBeingAssembled, part)
 		}
 	}
-
-	// log.Printf("DONE LOOPING %+v", messageParts)
-
-	// If there are any message parts left over, then add them at the end.
-	if len(messageParts) > 0 {
-		lines = append(lines, messageParts)
-	}
-
-	// log.Printf("RETURNING %+v", lines)
-	p.linesCache = lines
-	p.linesCacheWidth = width
+	
+	// Append final line to the collection.
+	lines = append(lines, lineBeingAssembled)
+	
 	return lines
+}
+
+func (p *PrintableMessage) Print(width int) {
+	for _, line := range p.Lines(width) {
+		lineContent := ""
+		for _, part := range line {
+			lineContent += part.Content
+		}
+		fmt.Println(lineContent)
+	}
 }

--- a/gateway/printable_message_test.go
+++ b/gateway/printable_message_test.go
@@ -1,7 +1,7 @@
 package gateway_test
 
 import (
-	// "fmt"
+	"fmt"
 	. "github.com/1egoman/slick/gateway"
 	"reflect"
 	"testing"
@@ -65,6 +65,16 @@ func TestPrintableMessageLines(t *testing.T) {
 				[]PrintableMessagePart{channel("hello world")},
 			},
 		},
+		// More than two lines.
+		{
+			MessageParts: []PrintableMessagePart{plainText("I have an official test build happening right now that will be ready for you tomorrow morning. I want to get a head start here just to make sure that nothing undexpected pops up.")},
+			Width:        65,
+			WrappedResult: [][]PrintableMessagePart{
+				[]PrintableMessagePart{plainText("I have an official test build happening right now that will be")},
+				[]PrintableMessagePart{plainText("ready for you tomorrow morning. I want to get a head start here")},
+				[]PrintableMessagePart{plainText("just to make sure that nothing undexpected pops up.")},
+			},
+		},
 		// Forced newlines should force a move to a newline, even if not needed due to length
 		{
 			MessageParts: []PrintableMessagePart{plainText("foo bar baz"), newline, channel("quux hello world")},
@@ -84,6 +94,7 @@ func TestPrintableMessageLines(t *testing.T) {
 			},
 		},
 	} {
+		fmt.Println("")
 		pm := NewPrintableMessage(test.MessageParts)
 		lines := pm.Lines(test.Width)
 

--- a/gateway/printable_message_test.go
+++ b/gateway/printable_message_test.go
@@ -1,7 +1,7 @@
 package gateway_test
 
 import (
-	"fmt"
+	// "fmt"
 	. "github.com/1egoman/slick/gateway"
 	"reflect"
 	"testing"
@@ -31,11 +31,11 @@ func TestPrintableMessageLines(t *testing.T) {
 		},
 		// Evenly wrap a message at it's part boundary
 		{
-			MessageParts: []PrintableMessagePart{plainText("hello world"), plainText("foo")},
+			MessageParts: []PrintableMessagePart{plainText("hello world"), plainText("bar")},
 			Width:        len("hello world"),
 			WrappedResult: [][]PrintableMessagePart{
 				[]PrintableMessagePart{plainText("hello world")},
-				[]PrintableMessagePart{plainText("foo")},
+				[]PrintableMessagePart{plainText("bar")},
 			},
 		},
 		// Ensure that a `PrintableMessagePart` can be broken at a line boundary to wrap to the next
@@ -44,7 +44,7 @@ func TestPrintableMessageLines(t *testing.T) {
 			MessageParts: []PrintableMessagePart{plainText("hello world"), plainText("foo bar")},
 			Width:        15,
 			WrappedResult: [][]PrintableMessagePart{
-				[]PrintableMessagePart{plainText("hello world"), plainText("foo")},
+				[]PrintableMessagePart{plainText("hello world"), plainText("foo ")},
 				[]PrintableMessagePart{plainText("bar")},
 			},
 		},
@@ -61,7 +61,7 @@ func TestPrintableMessageLines(t *testing.T) {
 			MessageParts: []PrintableMessagePart{plainText("foo bar baz"), channel("quux hello world")},
 			Width:        len("foo bar baz quux"),
 			WrappedResult: [][]PrintableMessagePart{
-				[]PrintableMessagePart{plainText("foo bar baz"), channel("quux")},
+				[]PrintableMessagePart{plainText("foo bar baz"), channel("quux ")},
 				[]PrintableMessagePart{channel("hello world")},
 			},
 		},
@@ -70,8 +70,8 @@ func TestPrintableMessageLines(t *testing.T) {
 			MessageParts: []PrintableMessagePart{plainText("I have an official test build happening right now that will be ready for you tomorrow morning. I want to get a head start here just to make sure that nothing undexpected pops up.")},
 			Width:        65,
 			WrappedResult: [][]PrintableMessagePart{
-				[]PrintableMessagePart{plainText("I have an official test build happening right now that will be")},
-				[]PrintableMessagePart{plainText("ready for you tomorrow morning. I want to get a head start here")},
+				[]PrintableMessagePart{plainText("I have an official test build happening right now that will be ")},
+				[]PrintableMessagePart{plainText("ready for you tomorrow morning. I want to get a head start here ")},
 				[]PrintableMessagePart{plainText("just to make sure that nothing undexpected pops up.")},
 			},
 		},
@@ -80,26 +80,16 @@ func TestPrintableMessageLines(t *testing.T) {
 			MessageParts: []PrintableMessagePart{plainText("foo bar baz"), newline, channel("quux hello world")},
 			Width:        len("foo bar baz quux"),
 			WrappedResult: [][]PrintableMessagePart{
-				[]PrintableMessagePart{plainText("foo bar baz"), newline},
-				[]PrintableMessagePart{channel("quux hello world")},
-			},
-		},
-
-		// Test for issue #9
-		{
-			MessageParts: []PrintableMessagePart{plainText("foo")},
-			Width:        -1, // This shouldn't ever happen, I just wanted to get `maximumLengthOfLastMessagePart` < 0
-			WrappedResult: [][]PrintableMessagePart{
-				[]PrintableMessagePart{plainText("foo")},
+				[]PrintableMessagePart{plainText("foo bar baz")},
+				[]PrintableMessagePart{newline, channel("quux hello world")},
 			},
 		},
 	} {
-		fmt.Println("")
 		pm := NewPrintableMessage(test.MessageParts)
 		lines := pm.Lines(test.Width)
 
 		if !reflect.DeepEqual(lines, test.WrappedResult) {
-			t.Errorf("%+v != %+v\n", lines, test.WrappedResult)
+			t.Errorf("\n%+v\n != \n%+v\n", SprintLines(test.Width, lines), SprintLines(test.Width, test.WrappedResult))
 		}
 	}
 }


### PR DESCRIPTION
- Rewrite message line splitting algorithm:
  - A bit faster
  - A bit simpler. Basically slowly add message parts to a slice and once that slice fills past a length, split at the last word boundary.
- Make tests more comprehensible:
  - Add `SprintLines` function for better visual comparisons of failing test cases